### PR TITLE
Update migrations

### DIFF
--- a/lib/player.js
+++ b/lib/player.js
@@ -39,7 +39,7 @@ var Player = {
 				if (results.changedRows > 0){
 					Logger.message("player score updated.");
 					socket.start_time = Timer.now();
-					socket.emit('score', '0.000');
+					socket.emit('score_minutes', 0);
 				}
 			});
 	},
@@ -99,7 +99,7 @@ var Player = {
 				return;
 			}
 
-			var query = connection.query("INSERT INTO `players` (`ip`, `initials`, `team`) VALUES (INET_ATON(?), ?, ?)", [ip, initials, team], function(error, result){
+			var query = connection.query("INSERT INTO `players` (`ip`, `initials`, `team`, `connected_at`) VALUES (INET_ATON(?), ?, ?, NOW())", [ip, initials, team], function(error, result){
 				connection.release();
 
 				if (error){

--- a/migrations/20150921191237-create-players-migration.js
+++ b/migrations/20150921191237-create-players-migration.js
@@ -1,57 +1,64 @@
 'use strict';
 
 module.exports = {
-  up: function (migration, DataTypes) {
-    /*
-      Add altering commands here.
-      Return a promise to correctly handle asynchronicity.
+	up: function (migration, DataTypes) {
+		/*
+			Add altering commands here.
+			Return a promise to correctly handle asynchronicity.
 
-      Example:
-      return queryInterface.createTable('users', { id: Sequelize.INTEGER });
-    */
-    migration.createTable('players',
-	{
-	  id: {
-	    type: DataTypes.INTEGER.UNSIGNED,
-	    primaryKey: true,
-	    autoIncrement: true
-	  },
-	  ip: {
-	    type: DataTypes.INTEGER.UNSIGNED,
-	  },
-	  initials: {
-	    type: DataTypes.STRING,
-	    length: 3
-	  },
-	  team: {
-	    type: DataTypes.STRING,
-	    length: 3
-	  },
-	  connected_at: {
-	    type: DataTypes.DATE
-	  },
-	  last_ping: {
-	    type: DataTypes.DATE
-	  }
+			Example:
+			return queryInterface.createTable('users', { id: Sequelize.INTEGER });
+		*/
+		migration.createTable('players',
+			{
+				id: {
+					type: DataTypes.INTEGER.UNSIGNED,
+					primaryKey: true,
+					autoIncrement: true,
+					allowNull: false
+				},
+				ip: {
+					type: DataTypes.INTEGER.UNSIGNED,
+					allowNull: false
+				},
+				initials: {
+					type: DataTypes.CHAR,
+					allowNull: false,
+					length: 3
+				},
+				team: {
+					type: DataTypes.CHAR,
+					length: 3
+				},
+				connected_at: {
+					type: DataTypes.DATE,
+					allowNull: false,
+					defaultValue: DataTypes.NOW
+				},
+				last_ping: {
+					type: DataTypes.DATE,
+					allowNull: false,
+					defaultValue: DataTypes.NOW
+				}
+			}
+		);
+
+		migration.addIndex('players',
+			['initials', 'team', 'connected_at', 'last_ping'],
+			{
+				indexName: 'intial_team_connection_index'
+			}
+		);
+	},
+
+	down: function (migration, DataTypes) {
+		/*
+			Add reverting commands here.
+			Return a promise to correctly handle asynchronicity.
+
+			Example:
+			return queryInterface.dropTable('users');
+		*/
+		migration.dropTable('players');
 	}
-    );
-
-    migration.addIndex('players',
-	['initials', 'team', 'connected_at', 'last_ping'],
-	{
-	  indexName: 'intial_team_connection_index'
-	}
-    );
-  },
-
-  down: function (migration, DataTypes) {
-    /*
-      Add reverting commands here.
-      Return a promise to correctly handle asynchronicity.
-
-      Example:
-      return queryInterface.dropTable('users');
-    */
-    migration.dropTable('players');
-  }
 };

--- a/migrations/20150921191237-create-players-migration.js
+++ b/migrations/20150921191237-create-players-migration.js
@@ -32,13 +32,11 @@ module.exports = {
 				},
 				connected_at: {
 					type: DataTypes.DATE,
-					allowNull: false,
-					defaultValue: DataTypes.NOW
+					allowNull: false
 				},
 				last_ping: {
 					type: DataTypes.DATE,
-					allowNull: false,
-					defaultValue: DataTypes.NOW
+					allowNull: false
 				}
 			}
 		);

--- a/public/js/shawarmaspin.js
+++ b/public/js/shawarmaspin.js
@@ -188,7 +188,6 @@ angular.module('ShawarmaSpinApp', []).controller('ShawarmaController', ['$interv
 
 	shawarma_ctrl.socket.on('disconnect', function(data){
 		shawarma_ctrl.connected = false;
-		shawarma_ctrl.socket.disconnect();
 	});
 
 	shawarma_ctrl.interval = 1.0 / 60.0;


### PR DESCRIPTION
Added not-null to the columns,
ensure new players have non-null connected-at datetime (sequelize doesn't use timestamps, and it's now() function only lets its models set the timestamp)
clients reconnect properly
