### PR TITLE
Socker service

### DIFF
--- a/lib/chat.js
+++ b/lib/chat.js
@@ -15,7 +15,7 @@ var Chat = {
 		// 	message: '#BOB You guys suck'
 		// }
 		socket.on('message.global', function(data){
-			if (!data || !data.message || !socket.initials){ // can't send nothing or send without initials.
+			if (!data || !data.text || !socket.initials){ // can't send nothing or send without initials.
 				return;
 			}
 
@@ -40,7 +40,7 @@ var Chat = {
 				packet.from.team = socket.team;
 			}
 
-			if ((match = message_re.exec(data.message)) !== null){
+			if ((match = message_re.exec(data.text)) !== null){
 
 				// send message to desired team
 				team = match[1];
@@ -60,7 +60,7 @@ var Chat = {
 			} else { // if we don't see #BOB at the start
 
 				// send message to global chat
-				packet.text = data.message;
+				packet.text = data.text;
 				socket.broadcast.emit('message.global', packet);
 			}
 
@@ -72,7 +72,7 @@ var Chat = {
 		// 	text: 'Yeah guys!'
 		// }
 		socket.on('message.team', function(data){
-			if (!data || !data.message || !socket.initials || !socket.team){ // can't send nothing or send without initials.
+			if (!data || !data.text || !socket.initials || !socket.team){ // can't send nothing or send without initials.
 				return;
 			}
 
@@ -80,7 +80,7 @@ var Chat = {
 				from: {
 					initials: socket.initials
 				},
-				text: data.message
+				text: data.text
 			};
 
 			socket.broadcast.to(socket.team).emit('message.team', packet);

--- a/public/js/shawarmaspin.js
+++ b/public/js/shawarmaspin.js
@@ -41,28 +41,18 @@ angular.module('ShawarmaSpinApp', []).controller('ShawarmaController', ['$interv
 		new_message: null
 	});
 
-	shawarma_ctrl.set_initials = function(){
-		if (shawarma_ctrl.display.initials){
-			shawarma_ctrl.display.initials = shawarma_ctrl.display.initials.substring(0, 3);
-		}
+	shawarma_ctrl.set_name = function(){
+		shawarma_ctrl.player.initials = Player.set_name(shawarma_ctrl.player.initials);
 		
-		if (shawarma_ctrl.player.initials != shawarma_ctrl.display.initials){
-			shawarma_ctrl.player.initials = shawarma_ctrl.display.initials;
-			shawarma_ctrl.socket.emit('set_initials', shawarma_ctrl.player.initials);
-		}
 	};
-	shawarma_ctrl.reset_initials = function(){
+	shawarma_ctrl.reset_name = function(){
 		shawarma_ctrl.display.initials = shawarma_ctrl.player.initials;
 	};
 
 	shawarma_ctrl.set_team = function(){
-		if (shawarma_ctrl.display.team){
-			shawarma_ctrl.display.team = shawarma_ctrl.display.team.substring(0, 3);
-		}
-		
-		if (shawarma_ctrl.player.team != shawarma_ctrl.display.team){
-			shawarma_ctrl.player.team = shawarma_ctrl.display.team;
-			shawarma_ctrl.socket.emit('set_team', shawarma_ctrl.player.team);
+		var result = Team.set_name(shawarma_ctrl.display.team);
+		if (result) {
+			shawarma_ctrl.player.team = result;
 			shawarma_ctrl.messages_team = [];
 		}
 	};
@@ -71,7 +61,7 @@ angular.module('ShawarmaSpinApp', []).controller('ShawarmaController', ['$interv
 	};
 
 	shawarma_ctrl.update_name = function(){
-		shawarma_ctrl.set_initials();
+		shawarma_ctrl.set_name();
 		shawarma_ctrl.set_team();
 	};
 	shawarma_ctrl.needs_name_updated = function(){
@@ -242,6 +232,7 @@ angular.module('ShawarmaSpinApp', []).controller('ShawarmaController', ['$interv
 	Socket.io.on('score_minutes', function(data){
 		shawarma_ctrl.player.score_minutes = parseFloat(data);
 	});
+}])
 
 .factory('Socket', [function() {
 	var Socket = {
@@ -249,6 +240,53 @@ angular.module('ShawarmaSpinApp', []).controller('ShawarmaController', ['$interv
 	};
 	return Socket;
 }])
+
+.factory('Player', ['Socket', function(Socket) {
+	var Player = {
+		initials: 'unk',
+		set_name: function(init) {
+			init = init.substring(0, 3);
+			if (init != this.initials) {
+				this.initials = init;
+				Socket.io.emit('set_initials', init);
+				return this.initials;
+			}
+			else {
+				return null;
+			}
+		}
+	};
+	return Player;
+}])
+
+.factory('Team', ['Socket', function(Socket) {
+	var Team = {
+		name: '',
+		set_name: function(name) {
+			name = name.substring(0, 3);
+			if (name !== this.name) {
+				this.name = name;
+				Socket.io.emit('set_team', name);
+				return this.name;
+			}
+			else {
+				return null;
+			}
+		}
+	};
+	return Team;
+}])
+
+.factory('Chat', ['Socket', function(Socket) {
+	var Chat = {
+		to_team: function() {
+
+		},
+		to_global: function() {
+
+		}
+	};
+	return Chat;
 }]);
 
 soundManager.setup({

--- a/public/js/shawarmaspin.js
+++ b/public/js/shawarmaspin.js
@@ -1,4 +1,4 @@
-angular.module('ShawarmaSpinApp', []).controller('ShawarmaController', ['$interval', function($interval) {
+angular.module('ShawarmaSpinApp', []).controller('ShawarmaController', ['$interval', 'Socket', 'Team', 'Player', function($interval, Socket, Team, Player) {
 	function print_score(score){
 		if (score < 10){
 			return score.toFixed(3);
@@ -88,7 +88,7 @@ angular.module('ShawarmaSpinApp', []).controller('ShawarmaController', ['$interv
 			});
 
 			// emit the message
-			shawarma_ctrl.socket.emit('message.global', {
+			Socket.io.emit('message.global', {
 				message: shawarma_ctrl.new_message_global
 			});
 			shawarma_ctrl.new_message_global = null;
@@ -105,23 +105,22 @@ angular.module('ShawarmaSpinApp', []).controller('ShawarmaController', ['$interv
 			});
 
 			// emit the message
-			shawarma_ctrl.socket.emit('message.team', {
+			Socket.io.emit('message.team', {
 				message: shawarma_ctrl.new_message_team
 			});
 			shawarma_ctrl.new_message_team = null;
 		}
 	};
 
-	shawarma_ctrl.socket = io.connect();
-	shawarma_ctrl.socket.on('connect', function(){
-		shawarma_ctrl.set_initials();
+	Socket.io.on('connect', function(){
+		shawarma_ctrl.set_name();
 		shawarma_ctrl.set_team();
 		shawarma_ctrl.player.score = 0.0;
 		shawarma_ctrl.display.score = 0.0;
 		shawarma_ctrl.connected = true;
 	});
 
-	shawarma_ctrl.socket.on('online', function(data){
+	Socket.io.on('online', function(data){
 		if (!data){
 			return;
 		}
@@ -134,7 +133,7 @@ angular.module('ShawarmaSpinApp', []).controller('ShawarmaController', ['$interv
 		}
 	});
 
-	shawarma_ctrl.socket.on('high_scores', function(data){
+	Socket.io.on('high_scores', function(data){
 		if (!data){
 			return;
 		}
@@ -150,7 +149,7 @@ angular.module('ShawarmaSpinApp', []).controller('ShawarmaController', ['$interv
 		}
 	});
 
-	shawarma_ctrl.socket.on('team_high_scores', function(data){
+	Socket.io.on('team_high_scores', function(data){
 		if (!data){
 			return;
 		}
@@ -168,7 +167,7 @@ angular.module('ShawarmaSpinApp', []).controller('ShawarmaController', ['$interv
 		}
 	});
 
-	shawarma_ctrl.socket.on('team_online', function(data){
+	Socket.io.on('team_online', function(data){
 		if (!data){
 			return;
 		}
@@ -183,7 +182,7 @@ angular.module('ShawarmaSpinApp', []).controller('ShawarmaController', ['$interv
 		}
 	});
 
-	shawarma_ctrl.socket.on('message.global', function(data){
+	Socket.io.on('message.global', function(data){
 		if (!data){
 			return;
 		}
@@ -197,7 +196,7 @@ angular.module('ShawarmaSpinApp', []).controller('ShawarmaController', ['$interv
 		messages.push(data);
 	});
 
-	shawarma_ctrl.socket.on('message.team', function(data){
+	Socket.io.on('message.team', function(data){
 		if (!data){
 			return;
 		}
@@ -211,16 +210,16 @@ angular.module('ShawarmaSpinApp', []).controller('ShawarmaController', ['$interv
 		messages.push(data);
 	});
 
-	shawarma_ctrl.socket.on('new_initials', function(data){
+	Socket.io.on('new_initials', function(data){
 		if (!data){
 			return;
 		}
 
 		shawarma_ctrl.player.initials = data;
-		shawarma_ctrl.reset_initials();
+		shawarma_ctrl.reset_name();
 	});
 
-	shawarma_ctrl.socket.on('new_team', function(data){
+	Socket.io.on('new_team', function(data){
 		if (!data){
 			return;
 		}
@@ -229,7 +228,7 @@ angular.module('ShawarmaSpinApp', []).controller('ShawarmaController', ['$interv
 		shawarma_ctrl.reset_team();
 	});
 
-	shawarma_ctrl.socket.on('disconnect', function(data){
+	Socket.io.on('disconnect', function(data){
 		shawarma_ctrl.connected = false;
 	});
 
@@ -240,9 +239,16 @@ angular.module('ShawarmaSpinApp', []).controller('ShawarmaController', ['$interv
 
 	}, shawarma_ctrl.interval * 1000);
 
-	shawarma_ctrl.socket.on('score_minutes', function(data){
+	Socket.io.on('score_minutes', function(data){
 		shawarma_ctrl.player.score_minutes = parseFloat(data);
 	});
+
+.factory('Socket', [function() {
+	var Socket = {
+		io: io.connect()
+	};
+	return Socket;
+}])
 }]);
 
 soundManager.setup({


### PR DESCRIPTION
Break out Player, Team and Chat functionality from the front-end controller into its own service. While mugging around the the Chat service, I also took the opportunity to normalize the message structure that's used  to communicate between front-end and server as well.

There are still more refactoring on the front-end to be done but I'm wrapping this pull request here so it's not overwhelming to review.
