### PR TITLE
Make sure the team name parsing is in upper case

### DIFF
--- a/lib/chat.js
+++ b/lib/chat.js
@@ -43,7 +43,7 @@ var Chat = {
 			if ((match = message_re.exec(data.text)) !== null){
 
 				// send message to desired team
-				team = match[1];
+				team = match[1].toUpperCase();
 				message = match[2];
 
 				packet.text = message;


### PR DESCRIPTION
Since all team names are in upper case, when we're parsing the team
name, they should be in upper case as well.
